### PR TITLE
extended the creation to allow custom node appending

### DIFF
--- a/js/iosOverlay.js
+++ b/js/iosOverlay.js
@@ -16,7 +16,8 @@ var iosOverlay = function(params) {
 		icon: null,
 		spinner: null,
 		duration: null,
-		id: null
+		id: null,
+		parentEl: null
 	};
 
 	// helper - merge two objects together, without using $.extend
@@ -75,7 +76,11 @@ var iosOverlay = function(params) {
 			overlayDOM.addEventListener("oAnimationEnd", handleAnim, false);
 			overlayDOM.addEventListener("animationend", handleAnim, false);
 		}
-		document.body.appendChild(overlayDOM);
+		if (params.parentEl) {
+			document.getElementById(params.parentEl).appendChild(overlayDOM);
+		} else {
+			document.body.appendChild(overlayDOM);
+		}
 		
 		settings.onbeforeshow();
 		// begin fade in


### PR DESCRIPTION
added a parameter to specify an element ID to which the overlay can be appended. If omitted, the overlay appending will default to the body.
