### PR TITLE
fix destroy method for parentEl appending

### DIFF
--- a/js/iosOverlay.js
+++ b/js/iosOverlay.js
@@ -121,7 +121,11 @@ var iosOverlay = function(params) {
 	};
 
 	var destroy = function() {
-		document.body.removeChild(overlayDOM);
+		if (params.parentEl) {
+			document.getElementById(params.parentEl).removeChild(overlayDOM);
+		} else {
+			document.body.removeChild(overlayDOM);
+		}
 	};
 
 	var update = function(params) {


### PR DESCRIPTION
Prior to this fix, the destroy method was always attempting to remove from document.body, even when the element was appended to a nominal parentEl.
