### PR TITLE
Ignore exception removing an already removed spinner

### DIFF
--- a/js/iosOverlay.js
+++ b/js/iosOverlay.js
@@ -134,7 +134,12 @@ var iosOverlay = function(params) {
 		}
 		if (params.icon) {
 			if (settings.spinner) {
-				settings.spinner.el.parentNode.removeChild(settings.spinner.el);
+				// It is possible for the spinner to be already removed, so
+				// ignore the exception
+				try {
+					settings.spinner.el.parentNode.removeChild(settings.spinner.el);
+				}
+				catch (e) {}
 			}
 			overlayDOM.innerHTML += '<img src="' + params.icon + '">';
 		}

--- a/js/iosOverlay.js
+++ b/js/iosOverlay.js
@@ -134,12 +134,9 @@ var iosOverlay = function(params) {
 		}
 		if (params.icon) {
 			if (settings.spinner) {
-				// It is possible for the spinner to be already removed, so
-				// ignore the exception
-				try {
-					settings.spinner.el.parentNode.removeChild(settings.spinner.el);
-				}
-				catch (e) {}
+				// Unless we set spinner to null, this will throw on the second update
+				settings.spinner.el.parentNode.removeChild(settings.spinner.el);
+				settings.spinner = null;
 			}
 			overlayDOM.innerHTML += '<img src="' + params.icon + '">';
 		}


### PR DESCRIPTION
It's possible in a complicated Backbone app that the spinner has already been removed by some other mechanism. This ignores the exception that results from that.
