### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "homepage": "https://github.com/izifortune/iOS-Overlay",
   "authors": [
-    "Tait Brown <taitbrown@gmail.com>",
+    "Tait Brown <taitbrown@gmail.com>"
   ],
   "description": "iOS Overlay/Notification Plugin for the Web!",
   "main": "js/iosOverlay.js",


### PR DESCRIPTION
Removed comma after single-item in 'authors' array which was causing problems installing this via bower.  Would previously fail with EMALFORMED Failed to read ...\bower.json.  Problem identified in #14 
